### PR TITLE
Switch to unpkg as default CDN provider

### DIFF
--- a/IMPORTMAP.md
+++ b/IMPORTMAP.md
@@ -8,14 +8,14 @@ This guide helps Rails developers set up railsui-stimulus with importmaps.
 
 ```ruby
 # Main package
-pin "railsui-stimulus", to: "https://cdn.jsdelivr.net/npm/railsui-stimulus@1.0.11/dist/importmap/index.js"
+pin "railsui-stimulus", to: "https://unpkg.com/railsui-stimulus@1.1.0/dist/importmap/index.js"
 
 # Required dependencies
-pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js"
-pin "tippy.js", to: "https://ga.jspm.io/npm:tippy.js@6.3.7/dist/tippy.esm.js"
-pin "flatpickr", to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/esm/index.js"
-pin "hotkeys-js", to: "https://ga.jspm.io/npm:hotkeys-js@3.13.15/dist/hotkeys.esm.js"
-pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.52.2/dist/index.js"
+pin "@hotwired/stimulus", to: "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js"
+pin "tippy.js", to: "https://unpkg.com/tippy.js@6.3.7/dist/tippy.esm.js"
+pin "flatpickr", to: "https://unpkg.com/flatpickr@4.6.13/dist/esm/index.js"
+pin "hotkeys-js", to: "https://unpkg.com/hotkeys-js@3.13.15/dist/hotkeys.esm.js"
+pin "stimulus-use", to: "https://unpkg.com/stimulus-use@0.52.2/dist/index.js"
 ```
 
 ### 2. Add CSS dependencies
@@ -27,14 +27,14 @@ Add to your `app/assets/stylesheets/application.css`:
 @import "https://unpkg.com/tippy.js@6.3.7/dist/tippy.css";
 
 /* Required for Date Range Picker component */
-@import "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css";
+@import "https://unpkg.com/flatpickr@4.6.13/dist/flatpickr.min.css";
 ```
 
 Or add to your layout file (`app/views/layouts/application.html.erb`):
 
 ```erb
 <%= stylesheet_link_tag "https://unpkg.com/tippy.js@6.3.7/dist/tippy.css", "data-turbo-track": "reload" %>
-<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
+<%= stylesheet_link_tag "https://unpkg.com/flatpickr@4.6.13/dist/flatpickr.min.css", "data-turbo-track": "reload" %>
 ```
 
 ### 3. Register components
@@ -106,11 +106,11 @@ pin "railsui-stimulus", to: "railsui-stimulus/index.js"
 pin_all_from "vendor/javascript/railsui-stimulus", under: "railsui-stimulus"
 
 # Dependencies (still need to be pinned)
-pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js"
-pin "tippy.js", to: "https://ga.jspm.io/npm:tippy.js@6.3.7/dist/tippy.esm.js"
-pin "flatpickr", to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/esm/index.js"
-pin "hotkeys-js", to: "https://ga.jspm.io/npm:hotkeys-js@3.13.15/dist/hotkeys.esm.js"
-pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.52.2/dist/index.js"
+pin "@hotwired/stimulus", to: "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js"
+pin "tippy.js", to: "https://unpkg.com/tippy.js@6.3.7/dist/tippy.esm.js"
+pin "flatpickr", to: "https://unpkg.com/flatpickr@4.6.13/dist/esm/index.js"
+pin "hotkeys-js", to: "https://unpkg.com/hotkeys-js@3.13.15/dist/hotkeys.esm.js"
+pin "stimulus-use", to: "https://unpkg.com/stimulus-use@0.52.2/dist/index.js"
 ```
 
 ## Component-Specific CSS Notes
@@ -142,12 +142,12 @@ You can use different CDN providers if preferred:
 
 **jsDelivr:**
 ```ruby
-pin "railsui-stimulus", to: "https://cdn.jsdelivr.net/npm/railsui-stimulus@1.0.11/dist/importmap/index.js"
+pin "railsui-stimulus", to: "https://cdn.jsdelivr.net/npm/railsui-stimulus@1.1.0/dist/importmap/index.js"
 ```
 
-**unpkg:**
+**JSPM:**
 ```ruby
-pin "railsui-stimulus", to: "https://unpkg.com/railsui-stimulus@1.0.11/dist/importmap/index.js"
+pin "railsui-stimulus", to: "https://ga.jspm.io/npm:railsui-stimulus@1.1.0/dist/importmap/index.js"
 ```
 
 ## Need Help?

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ Rails 7+ ships with importmap-rails by default. This method doesn't require npm 
 
 ```ruby
 # config/importmap.rb
-pin "railsui-stimulus", to: "https://cdn.jsdelivr.net/npm/railsui-stimulus@1.0.11/dist/importmap/index.js"
+pin "railsui-stimulus", to: "https://unpkg.com/railsui-stimulus@1.1.0/dist/importmap/index.js"
 
 # Pin dependencies
-pin "@hotwired/stimulus", to: "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js"
-pin "tippy.js", to: "https://ga.jspm.io/npm:tippy.js@6.3.7/dist/tippy.esm.js"
-pin "flatpickr", to: "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/esm/index.js"
-pin "hotkeys-js", to: "https://ga.jspm.io/npm:hotkeys-js@3.13.15/dist/hotkeys.esm.js"
-pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.52.2/dist/index.js"
+pin "@hotwired/stimulus", to: "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js"
+pin "tippy.js", to: "https://unpkg.com/tippy.js@6.3.7/dist/tippy.esm.js"
+pin "flatpickr", to: "https://unpkg.com/flatpickr@4.6.13/dist/esm/index.js"
+pin "hotkeys-js", to: "https://unpkg.com/hotkeys-js@3.13.15/dist/hotkeys.esm.js"
+pin "stimulus-use", to: "https://unpkg.com/stimulus-use@0.52.2/dist/index.js"
 ```
 
 3. Add required CSS files to your `app/assets/stylesheets/application.css` or include via CDN:
@@ -47,14 +47,14 @@ pin "stimulus-use", to: "https://ga.jspm.io/npm:stimulus-use@0.52.2/dist/index.j
 @import "https://unpkg.com/tippy.js@6.3.7/dist/tippy.css";
 
 /* For Date Range Picker component */
-@import "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css";
+@import "https://unpkg.com/flatpickr@4.6.13/dist/flatpickr.min.css";
 ```
 
 Or in your layout file:
 
 ```erb
 <%= stylesheet_link_tag "https://unpkg.com/tippy.js@6.3.7/dist/tippy.css" %>
-<%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css" %>
+<%= stylesheet_link_tag "https://unpkg.com/flatpickr@4.6.13/dist/flatpickr.min.css" %>
 ```
 
 4. Import components in your JavaScript entrypoint (e.g., `app/javascript/controllers/index.js`):

--- a/importmap.json
+++ b/importmap.json
@@ -1,11 +1,11 @@
 {
   "imports": {
-    "@hotwired/stimulus": "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js",
-    "tippy.js": "https://ga.jspm.io/npm:tippy.js@6.3.7/dist/tippy.esm.js",
-    "flatpickr": "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/esm/index.js",
-    "hotkeys-js": "https://ga.jspm.io/npm:hotkeys-js@3.13.15/dist/hotkeys.esm.js",
-    "stimulus-use": "https://ga.jspm.io/npm:stimulus-use@0.52.2/dist/index.js"
+    "@hotwired/stimulus": "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js",
+    "tippy.js": "https://unpkg.com/tippy.js@6.3.7/dist/tippy.esm.js",
+    "flatpickr": "https://unpkg.com/flatpickr@4.6.13/dist/esm/index.js",
+    "hotkeys-js": "https://unpkg.com/hotkeys-js@3.13.15/dist/hotkeys.esm.js",
+    "stimulus-use": "https://unpkg.com/stimulus-use@0.52.2/dist/index.js"
   },
   "scopes": {},
-  "description": "Importmap configuration for railsui-stimulus. These are the CDN URLs for required dependencies. You can also use different CDN providers like unpkg or skypack, or pin specific versions via importmap-rails."
+  "description": "Importmap configuration for railsui-stimulus. These are the CDN URLs for required dependencies using unpkg. You can also use different CDN providers like jsDelivr or JSPM, or pin specific versions via importmap-rails."
 }

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
     <script type="importmap">
       {
         "imports": {
-          "@hotwired/stimulus": "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js",
+          "@hotwired/stimulus": "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js",
           "railsui-stimulus": "./dist/railsui-stimulus.module.js"
         }
       }

--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
     <script>hljs.highlightAll();</script>
 
     <!--
-      Bundled Build Configuration
+      Importmap Configuration (unpkg CDN)
 
-      This demo uses the BUNDLED ESM version of railsui-stimulus.
-      All dependencies are included in the bundle.
+      This demo uses the importmap distribution from unpkg CDN.
+      This is the recommended setup for Rails 7+ applications.
 
       For Rails importmap apps, see IMPORTMAP.md for setup instructions.
       For npm/bundler apps, see BUILD.md for setup instructions.
@@ -32,7 +32,11 @@
       {
         "imports": {
           "@hotwired/stimulus": "https://unpkg.com/@hotwired/stimulus@3.2.2/dist/stimulus.js",
-          "railsui-stimulus": "./dist/railsui-stimulus.module.js"
+          "railsui-stimulus": "https://unpkg.com/railsui-stimulus@1.1.0/dist/importmap/index.js",
+          "tippy.js": "https://unpkg.com/tippy.js@6.3.7/dist/tippy.esm.js",
+          "flatpickr": "https://unpkg.com/flatpickr@4.6.13/dist/esm/index.js",
+          "hotkeys-js": "https://unpkg.com/hotkeys-js@3.13.15/dist/hotkeys.esm.js",
+          "stimulus-use": "https://unpkg.com/stimulus-use@0.52.2/dist/index.js"
         }
       }
     </script>

--- a/index.html
+++ b/index.html
@@ -20,23 +20,19 @@
     <script>hljs.highlightAll();</script>
 
     <!--
-      Importmap Configuration
+      Bundled Build Configuration
 
-      This demo uses the UNBUNDLED importmap version of railsui-stimulus.
-      All dependencies are loaded separately via CDN.
+      This demo uses the BUNDLED ESM version of railsui-stimulus.
+      All dependencies are included in the bundle.
 
-      For Rails apps, see IMPORTMAP.md for setup instructions.
+      For Rails importmap apps, see IMPORTMAP.md for setup instructions.
       For npm/bundler apps, see BUILD.md for setup instructions.
     -->
     <script type="importmap">
       {
         "imports": {
           "@hotwired/stimulus": "https://ga.jspm.io/npm:@hotwired/stimulus@3.2.2/dist/stimulus.js",
-          "railsui-stimulus": "./dist/importmap/index.js",
-          "tippy.js": "https://ga.jspm.io/npm:tippy.js@6.3.7/dist/tippy.esm.js",
-          "flatpickr": "https://ga.jspm.io/npm:flatpickr@4.6.13/dist/esm/index.js",
-          "hotkeys-js": "https://ga.jspm.io/npm:hotkeys-js@3.13.15/dist/hotkeys.esm.js",
-          "stimulus-use": "https://ga.jspm.io/npm:stimulus-use@0.52.2/dist/index.js"
+          "railsui-stimulus": "./dist/railsui-stimulus.module.js"
         }
       }
     </script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "railsui-stimulus",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "description": "Rails UI Stimulus.js Components",
   "main": "./dist/railsui-stimulus.cjs",
   "module": "./dist/railsui-stimulus.module.js",


### PR DESCRIPTION
## Summary
Switch from JSPM/jsDelivr to unpkg as the default CDN provider across all documentation and examples.

## Changes
- **importmap.json**: Updated all dependency URLs to use unpkg
- **IMPORTMAP.md**: 
  - Updated Quick Start example to use unpkg
  - Updated self-hosted example to use unpkg
  - Updated version to 1.1.0
  - Kept jsDelivr and JSPM as alternative options
- **README.md**: 
  - Updated importmap installation to use unpkg
  - Updated CSS CDN URLs to use unpkg
  - Updated version to 1.1.0
- **index.html**: Switched demo to bundled build (works locally without CDN wait)

## Rationale
unpkg has the fastest CDN propagation time (~1-2 minutes) compared to jsDelivr (5-15 min) and JSPM (5-10 min), making it better for users who want to get started quickly after an npm publish.

## Testing
- [x] All documentation examples use consistent unpkg URLs
- [x] Alternative CDN providers documented
- [x] Demo works with bundled build locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)